### PR TITLE
Include release notes and multiple releases

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -91,8 +91,13 @@ a {
 }
 
 .version {
+  cursor: default;
   font-size: 0.85em;
   opacity: 0.75;
+
+  a {
+    font-weight: 600;
+  }
 }
 
 .badge {

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@ layout: default
           {% assign repo_secs = release.release_date | date: '%s' %}
           {% assign repo_age_secs = now_secs | minus: repo_secs %}
 
-          {% comment %} Always show the first, plus any releases in the past month {% endcomment %}
-          {% if forloop.first or repo_age_secs < 2592000 %}
+          {% comment %} Always show the first, plus any releases in the past two months {% endcomment %}
+          {% if forloop.first or repo_age_secs < 5184000 %}
             <details>
               <summary class="version">
                 <a href="{{ release.href }}">{{ release.version }}</a>

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@ layout: default
           {% assign repo_secs = release.release_date | date: '%s' %}
           {% assign repo_age_secs = now_secs | minus: repo_secs %}
 
-          {% comment %} Always show the first, plus any releases in the past two months {% endcomment %}
-          {% if forloop.first or repo_age_secs < 5184000 %}
+          {% comment %} Always show the first, plus any releases in the past 45 days {% endcomment %}
+          {% if forloop.first or repo_age_secs < 3888000 %}
             <details>
               <summary class="version">
                 <a href="{{ release.href }}">{{ release.version }}</a>

--- a/index.html
+++ b/index.html
@@ -19,16 +19,25 @@ layout: default
     <tr id="{{ repo.name }}" >
       <td class="release">
         <a href="{{ repo_href }}" class="name">{{ repo.name }}</a>
-        <details>
-          <summary>
-            <a class="version" href="{{ repo.releases.first.href }}">
-                {{ repo.releases.first.version }} on
-                <time datetime="{{ repo.releases.first.release_date }}" title="{{ repo.releases.first.release_date }}">{{ repo.releases.first.release_date | date: "%b %e, %Y" }}</time>
-            </a>
-          </summary>
-          <h4>{{ repo.releases.first.title }}</h4>
-          <p>{{ repo.releases.first.body }}</p>
-        </details>
+
+        {% assign now_secs = site.time | date: '%s' %}
+        {% for release in repo.releases %}
+          {% assign repo_secs = release.release_date | date: '%s' %}
+          {% assign repo_age_secs = now_secs | minus: repo_secs %}
+
+          {% comment %} Always show the first, plus any releases in the past month {% endcomment %}
+          {% if forloop.first or repo_age_secs < 2592000 %}
+            <details>
+              <summary class="version">
+                <a href="{{ release.href }}">{{ release.version }}</a>
+                on
+                <time datetime="{{ release.release_date }}" title="{{ release.release_date }}">{{ release.release_date | date: "%b %e, %Y" }}</time>
+              </summary>
+              <h4>{{ release.title }}</h4>
+              <p>{{ release.body }}</p>
+            </details>
+          {% endif %}
+        {% endfor %}
       </td>
       <td class="status">
         {% if repo.new_commits == 0 %}

--- a/index.html
+++ b/index.html
@@ -19,7 +19,14 @@ title: Releases
     <tr id="{{ repo.name }}" >
       <td>
         <a href="{{ repo_href }}" class="name">{{ repo.name }}</a>
-        <a class="version" href="{{ repo.releases.first.href }}">{{ repo.releases.first.version }}</a>
+        <details>
+          <summary>
+            <a class="version" href="{{ repo.releases.first.href }}">{{ repo.releases.first.version }}</a>
+          </summary>
+          <h4>{{ repo.releases.first.title }}</h4>
+          <p>{{ repo.releases.first.body }}</p>
+        </details>
+
       </td>
       <td>
         <time datetime="{{ repo.releases.first.release_date }}" title="{{ repo.releases.first.release_date }}">{{ repo.releases.first.release_date | date: "%b %e, %Y" }}</time>


### PR DESCRIPTION
- Fixes #3 using a description/summary expander
- Fixes #6 by showing the latest release plus any releases < 30 days old

I don't love the styling of the expanders, but it's super handy to be able to easily see the details when needed.

Most of the time only one release will show up. But when there have been multiple releases in the past month, it's super handy to see (i.e. to know if one release was a critical bugfix or just when writing monthly updates posts).

Includes the title in case we ever do anything useful with them (and to keep this somewhat generalizable for other orgs).