### PR TITLE
Add Dockerized build environment & scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,12 @@
-FROM ruby:2.7-buster
-
-# Install program to configure locales as per
-# https://github.com/jekyll/jekyll/issues/4268#issuecomment-167406574
-RUN apt-get update && apt-get install -y locales
-RUN dpkg-reconfigure locales && \
-  locale-gen C.UTF-8 && \
-  /usr/sbin/update-locale LANG=C.UTF-8
-
-# Install needed default locale for Makefly
-RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
+FROM jekyll/jekyll:4
 
 # Set default locale for the environment
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-RUN mkdir -p /opt/io/elementary/releases
-WORKDIR /opt/io/elementary/releases
-
-COPY Gemfile ./
-RUN gem install jekyll && bundle install
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
 
 ENTRYPOINT ["/usr/local/bin/bundle", "exec", \
   "jekyll", "serve",   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:2.7-buster
+
+# Install program to configure locales as per
+# https://github.com/jekyll/jekyll/issues/4268#issuecomment-167406574
+RUN apt-get update && apt-get install -y locales
+RUN dpkg-reconfigure locales && \
+  locale-gen C.UTF-8 && \
+  /usr/sbin/update-locale LANG=C.UTF-8
+
+# Install needed default locale for Makefly
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
+
+# Set default locale for the environment
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+RUN mkdir -p /opt/io/elementary/releases
+WORKDIR /opt/io/elementary/releases
+
+COPY Gemfile ./
+RUN gem install jekyll && bundle install
+
+ENTRYPOINT ["/usr/local/bin/bundle", "exec", \
+  "jekyll", "serve",   \
+  "--host", "0.0.0.0", \
+  "--port", "4000"]

--- a/README.md
+++ b/README.md
@@ -12,28 +12,44 @@ zlib1g-dev
 ```
 
 We recommend installing gems to a (hidden) directory in your home folder:
-```bash
-echo '' >> ~/.bashrc
-echo '# Install Ruby Gems to ~/.gems' >> ~/.bashrc
-echo 'export GEM_HOME="$HOME/.gems"' >> ~/.bashrc
-echo 'export PATH="$HOME/.gems/bin:$PATH"' >> ~/.bashrc
-echo '' >> ~/.bashrc
-source ~/.bashrc
+```sh-session
+$ echo '' >> ~/.bashrc
+$ echo '# Install Ruby Gems to ~/.gems' >> ~/.bashrc
+$ echo 'export GEM_HOME="$HOME/.gems"' >> ~/.bashrc
+$ echo 'export PATH="$HOME/.gems/bin:$PATH"' >> ~/.bashrc
+$ echo '' >> ~/.bashrc
+$ source ~/.bashrc
 ```
 
 Install jekyll and bundler:
-```bash
-gem install jekyll bundler
+```sh-session
+$ gem install jekyll bundler
 ```
 
 Install gems:
-```bash
-bundle install
+```sh-session
+$ bundle install
 ```
 
 Build and serve locally with:
-```bash
-bundle exec jekyll serve --host 0.0.0.0
+```sh-session
+$ bundle exec jekyll serve --host 0.0.0.0
 ```
 
 The site should now be available at http://0.0.0.0:4000/ on your local machine, and your local machine's IP address on your network—great for testing on mobile OSes.
+
+### Alternative: building with Docker
+
+You'll need Docker installed on your system.
+
+Build the Docker image:
+```sh-session
+$ bin/build-container
+```
+
+Build and serve locally with:
+```sh-session
+$ bin/serve
+```
+
+The site should now be available at http://0.0.0.0:4000/

--- a/bin/build-container
+++ b/bin/build-container
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $(git rev-parse --show-toplevel) # work from repo dir
+docker build -t io.elementary.releases .

--- a/bin/serve
+++ b/bin/serve
@@ -2,6 +2,6 @@
 
 cd $(git rev-parse --show-toplevel) # work from repo dir
 docker run --rm -it \
-       -v $(pwd):/opt/io/elementary/releases/ \
+       -v $(pwd):/srv/jekyll/ \
        -p 4000:4000 \
        io.elementary.releases

--- a/bin/serve
+++ b/bin/serve
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $(git rev-parse --show-toplevel) # work from repo dir
+docker run --rm -it \
+       -v $(pwd):/opt/io/elementary/releases/ \
+       -p 4000:4000 \
+       io.elementary.releases


### PR DESCRIPTION
### This PR contains
- `bin/build-container`, a script which builds a Jekyll container using the local Gemfile
- `Dockerfile`, which provides further build instructions to Docker
- `bin/serve`, a script which serves the site using the built container
- updates to the README explaining how to use the above

### Motivation

By managing dependencies in containers, I avoid package version conflicts on my machine and I can present easily reproducible build and test instructions to others.

### Dependencies

This PR adds an optional dependency on Docker.

### How to test

Notice that there's a new sub-header under "Building" in the README. Check out this branch and follow the instructions there to build a container and serve the site. This should succeed with no errors.

I tested this with Docker version 19.03.8, build afacb8b7f0