### PR TITLE
Bump warn threshold to 15

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,11 +32,11 @@ layout: default
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commit</a>
           </span>
-        {% elsif repo.new_commits > 1 and repo.new_commits < 10 %}
+        {% elsif repo.new_commits > 1 and repo.new_commits < 15 %}
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
-        {% elsif repo.new_commits >= 10 and repo.new_commits < 50 %}
+        {% elsif repo.new_commits >= 15 and repo.new_commits < 50 %}
           <span class="badge warn">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>


### PR DESCRIPTION
10 seems to be too low. We already have things released within a week at 10 because of translation commits. 2 of them are from the bot updating translation templates