### PR TITLE
Fix #22: Don't mark release as critical if it's less than a month old

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install PyGithub
+        pip install timeago
     - name: Run script and commit changes
       run: |
         python release.py

--- a/index.html
+++ b/index.html
@@ -42,11 +42,11 @@ layout: default
           <span class="badge warn">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
-        {% elsif repo.new_commits > 1 and repo.new_commits < 10 %}
+        {% elsif repo.new_commits > 1 and repo.new_commits < 15 %}
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
-        {% elsif repo.new_commits >= 10 and repo.new_commits < 50 %}
+        {% elsif repo.new_commits >= 15 and repo.new_commits < 50 %}
           <span class="badge warn">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>

--- a/index.html
+++ b/index.html
@@ -30,27 +30,23 @@ layout: default
       <td class="status">
         {% if repo.new_commits == 0 %}
           <span class="badge good">Up to date</span>
+        {% elsif release_date > (now - 2419200) %}
+          <span class="badge good">
+            <a href="{{ commits_href }}">Recent Release</a>
+          </span>
         {% elsif repo.new_commits == 1 %}
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commit</a>
           </span>
-        {% elsif release_date > (now - 2419200) and repo.new_commits < 50 %}
+        {% elsif repo.new_commits <= 15 %}
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
-        {% elsif release_date > (now - 2419200) and repo.new_commits >= 50 %}
+        {% elsif repo.new_commits <= 50 %}
           <span class="badge warn">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
-        {% elsif repo.new_commits > 1 and repo.new_commits < 15 %}
-          <span class="badge">
-            <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
-          </span>
-        {% elsif repo.new_commits >= 15 and repo.new_commits < 50 %}
-          <span class="badge warn">
-            <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
-          </span>
-        {% elsif repo.new_commits >= 50 %}
+        {% else %}
           <span class="badge critical">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>

--- a/index.html
+++ b/index.html
@@ -34,8 +34,12 @@ layout: default
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commit</a>
           </span>
-        {% elsif release_date > (now - 2419200) %}
+        {% elsif release_date > (now - 2419200) and repo.new_commits < 50 %}
           <span class="badge">
+            <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
+          </span>
+        {% elsif release_date > (now - 2419200) and repo.new_commits >= 50 %}
+          <span class="badge warn">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
         {% elsif repo.new_commits > 1 and repo.new_commits < 10 %}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@ layout: default
 ---
 
 {% assign org_href = "https://github.com/elementary" %}
+{% assign now = 'now' | date: '%s' | plus: 0 %}
 
 <table class="releases">
   <thead>
@@ -16,6 +17,7 @@ layout: default
     {% unless site.data.blacklist contains repo.name %}
     {% assign repo_href = org_href | append: "/" | append: repo.name %}
     {% assign commits_href = repo_href | append: "/compare/" | append: repo.releases.first.version | append: "...master" %}
+    {% assign release_date = repo.releases.first.release_date | date: '%s' | plus: 0 %}
     <tr id="{{ repo.name }}" >
       <td class="release">
         <a href="{{ repo_href }}" class="name">{{ repo.name }}</a>
@@ -32,11 +34,15 @@ layout: default
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commit</a>
           </span>
-        {% elsif repo.new_commits > 1 and repo.new_commits < 15 %}
+        {% elsif release_date > (now - 2419200) %}
           <span class="badge">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
-        {% elsif repo.new_commits >= 15 and repo.new_commits < 50 %}
+        {% elsif repo.new_commits > 1 and repo.new_commits < 10 %}
+          <span class="badge">
+            <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
+          </span>
+        {% elsif repo.new_commits >= 10 and repo.new_commits < 50 %}
           <span class="badge warn">
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ layout: default
     {% unless site.data.blacklist contains repo.name %}
     {% assign repo_href = org_href | append: "/" | append: repo.name %}
     {% assign commits_href = repo_href | append: "/compare/" | append: repo.releases.first.version | append: "...master" %}
-    {% assign release_date = repo.releases.first.release_date | date: '%s' | plus: 0 %}
+    {% assign release_date_seconds = repo.releases.first.release_date | date: '%s' | plus: 0 %}
     <tr id="{{ repo.name }}" >
       <td class="release">
         <a href="{{ repo_href }}" class="name">{{ repo.name }}</a>
@@ -30,7 +30,7 @@ layout: default
       <td class="status">
         {% if repo.new_commits == 0 %}
           <span class="badge good">Up to date</span>
-        {% elsif release_date > (now - 2419200) %}
+        {% elsif release_date_seconds > (now - 2419200) %}
           <span class="badge good">
             <a href="{{ commits_href }}">Recent Release</a>
           </span>
@@ -51,6 +51,9 @@ layout: default
             <a href="{{ commits_href }}">{{ repo.new_commits }} commits</a>
           </span>
         {% endif %}
+        <sub class="timeago"><time datetime="{{ repo.releases.first.release_date }}">
+          {{ repo.releases.first.timeago }}
+        </time></sub>
       </td>
     </tr>
     {% endunless %}

--- a/release.py
+++ b/release.py
@@ -1,4 +1,5 @@
 import datetime
+import timeago
 import json
 import os
 import sys
@@ -52,6 +53,7 @@ for repo in repos:
     releases.append ({
       "version": release.tag_name,
       "release_date": release.created_at.isoformat(),
+      "timeago": timeago.format(release.created_at, now),
       "title": release.title,
       "body": release.body,
       "href": release.html_url


### PR DESCRIPTION
- Fixes #22: Don't mark release as critical if it's less than a month old
- Get now and release_date as integers.
- Stop marking recent releases with warnings and criticals.
- Warn over 50 commits, even with recent releases.