### PR TITLE
Move last updated time to top.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,8 +17,8 @@
           {{ site.description }}
         {% endif %}
       </p>
-      {{ content | replace: '<a href="http', '<a rel="nofollow noopener noreferrer" target="_blank" href="http' }}
       <p><small>Last updated <time datetime="{{ site.time }}" title="{{ site.time }}">{{ site.time | date: "%b %e, %Y at %l:%M %p %Z" }}</time>.</small></p>
+      {{ content | replace: '<a href="http', '<a rel="nofollow noopener noreferrer" target="_blank" href="http' }}
     </section>
   </body>
 </html>


### PR DESCRIPTION
The `last updated time` is an impactful data point and it tells about the validity of the data the time at which it is seen. It is currently placed at the bottom of the page making it less visible.

##  Purpose

We can improve its visibility by moving it to the top of the page just below the site description and above the table making it clearly visible.

```
name: Move last updated time to top.
about: We can improve its visibility by moving it to the top of the page just below the site description and above the table making it clearly visible.
title: 'LastUpdatedTime: Move to top'
labels: 'enhancement, hacktoberfest, Priority: Wishlist'
assignees: 'Ashrockzzz2003'
```

## Updates

- [x] In [default.html](https://github.com/elementary/releases/blob/main/_layouts/default.html), Moved the `last updated time` below site description and above the table.

Fixes https://github.com/elementary/releases/issues/56