### PR TITLE
Use inline-link of site in README replacing plain-text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Releases
 
-See all releases and the status of repos at releases.elementary.io
+See all releases and the status of repos at [releases.elementary.io](https://releases.elementary.io)
 
 ## Building
 


### PR DESCRIPTION
## Problem

The website's URL in the README currently is in plain-text. It is hard to copy and paste it in the url bar each time.

https://github.com/elementary/releases/blob/9d827375b72371b9766274b606a71f312246380a/README.md?plain=1#L3

##  Proposal

Use inline-link in README to improve accessibility of the link.

```
name: Use inline-link of site in README replacing plain-text.
about: Use inline-link in README to improve accessibility of the link.
title: 'README: Use inline-link of site replacing plain-text.'
labels: 'enhancement, hacktoberfest, Priority: Wishlist'
assignees: 'Ashrockzzz2003'
```

## Updates

- [x] In [README.md](https://github.com/elementary/releases/blob/main/README.md), updated the URL of the site from plain-text to inline-link.

Fixes https://github.com/elementary/releases/issues/58