### PR TITLE
ci: Fix python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION


The ubuntu-latest image [now defaults to 24.04](https://github.com/actions/runner-images/issues/10636), which does not provide Python 3.8. So now the CI [fails](https://github.com/elementary/releases/actions/runs/12317052995/job/34378693383). I've [verified](https://github.com/bobby285271/releases/actions/runs/12317807442/job/34381106565) that the Python script runs fine with Python 3.12.

I rely on https://releases.elementary.io heavily for downstream packaging :-)

