### PR TITLE
Bump Ruby to 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '~> 2.7'
+ruby '~> 3.2'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
@@ -17,7 +17,7 @@ gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", "~> 204", group: :jekyll_plugins
+gem "github-pages", "~> 232", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
@@ -29,3 +29,6 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
+# Required to run jekyll with Ruby 3.x
+# See https://github.com/jekyll/jekyll/issues/8523
+gem "webrick", "~> 1.9"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby '~> 3.2'
-
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:


### PR DESCRIPTION
Fixes #63

I removed the version limitation completely because this seemed to be added in #44 `as it's needed by github-pages`, but [github-pages](https://rubygems.org/gems/github-pages/versions/232?locale=en) supports Ruby 3 in 2025 of course:

![image](https://github.com/user-attachments/assets/4db04b98-9b9b-4109-9313-e1ada0d62cf8)

I confirmed this works locally, but I'm not sure if this won't break our production environment (releases.elementary.io)
